### PR TITLE
Add config entry to adjust hostile mob health

### DIFF
--- a/code/controllers/configuration/entries/phoenix.dm
+++ b/code/controllers/configuration/entries/phoenix.dm
@@ -2,3 +2,8 @@
 	config_entry_value = 8 //0 means disabled
 	integer = TRUE
 	min_val = -1
+
+/datum/config_entry/number/hostile_health_mult //multiplier for /simple_animal/hostile health
+	config_entry_value = 1
+	integer = FALSE
+	min_val = 0.1

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -70,6 +70,9 @@
 /mob/living/simple_animal/hostile/Initialize(mapload)
 	. = ..()
 	wanted_objects = typecacheof(wanted_objects)
+	var/healthmult = CONFIG_GET(number/hostile_health_mult)
+	health = health * healthmult
+	maxHealth = maxHealth * healthmult
 
 /mob/living/simple_animal/hostile/Destroy()
 	//We can't use losetarget here because fucking cursed blobs override it to do nothing the motherfuckers

--- a/config/phoenix.txt
+++ b/config/phoenix.txt
@@ -1,3 +1,6 @@
 ## number of active players below which an AI may spawn with prebuilt shells if mapped.
 #  set to -1 to always spawn autoshells.
 AUTOSHELL_POP 8
+
+## multiplier for simple_animal/hostile maxhealth.
+HOSTILE_HEALTH_MULT 1.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds config entry that multiplies starting health of /mob/living/simple_animal/hostile mobs. As long as they all call their super constructor, which they SHOULD.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Was discussed in discord. Very simple adjustment to maybe make some of them less of a pushover.

## Changelog
:cl:
add: Added config entry for adjusting hostile simplemob health.
config: Simplemob health set to 1.5x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
