### PR TITLE
Crashedship.dmm Hotfix 2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -172,8 +172,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = 24;
-	pixel_y = 0;
+	dir = 4;
 	environ = 0
 	},
 /obj/structure/cable,
@@ -409,8 +408,7 @@
 /obj/effect/spawner/lootdrop/memeorgans,
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = 24;
-	pixel_y = 0;
+	dir = 4;
 	environ = 0
 	},
 /obj/item/food/salami,
@@ -465,8 +463,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	pixel_y = 0;
+	dir = 8;
 	environ = 0
 	},
 /turf/open/floor/iron/corner{
@@ -741,8 +738,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = 0;
-	pixel_y = -24;
+	dir = 2;
 	environ = 0
 	},
 /turf/open/floor/wood,
@@ -1049,8 +1045,7 @@
 /obj/item/kitchen/knife,
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	pixel_y = 0;
+	dir = 8;
 	environ = 0
 	},
 /turf/open/floor/iron/white/textured_half{
@@ -1232,8 +1227,7 @@
 /obj/item/food/hugemushroomslice,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	pixel_y = 0;
+	dir = 8;
 	environ = 0
 	},
 /obj/structure/cable,
@@ -2415,8 +2409,7 @@
 "gy" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = 24;
-	pixel_y = 0;
+	dir = 4;
 	environ = 0
 	},
 /turf/open/floor/iron/half{
@@ -2598,8 +2591,7 @@
 /obj/effect/spawner/lootdrop/clothes,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	pixel_y = 0;
+	dir = 8;
 	environ = 0
 	},
 /turf/open/floor/iron/half{
@@ -2667,8 +2659,7 @@
 /obj/item/stack/cable_coil,
 /obj/effect/spawner/lootdrop/powercell,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	pixel_y = 0;
+	dir = 8;
 	environ = 0
 	},
 /obj/structure/cable,
@@ -3132,8 +3123,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/low_wall/plastitanium,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	pixel_y = 0;
+	dir = 8;
 	environ = 0
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -4356,8 +4346,7 @@
 "lB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	pixel_y = 0;
+	dir = 8;
 	environ = 0
 	},
 /obj/item/plate,

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -55,8 +55,8 @@
 /turf/open/floor/iron/half,
 /area/awaymission/bmpship/midship/bar)
 "aj" = (
-/turf/closed/wall/mineral/titanium/interior,
-/area/awaymission/bmpship/aft/storage)
+/turf/closed/wall/mineral/titanium/overspace,
+/area/awaymission/bmpship/aft/tribay)
 "ak" = (
 /obj/machinery/smartfridge/drinks,
 /obj/effect/decal/cleanable/dirt,
@@ -173,6 +173,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = 24;
+	pixel_y = 0;
 	environ = 0
 	},
 /obj/structure/cable,
@@ -348,7 +349,7 @@
 "bc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/half,
-/area/awaymission/bmpship/aft/storage)
+/area/awaymission/bmpship/aft/quarters)
 "bd" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -409,6 +410,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = 24;
+	pixel_y = 0;
 	environ = 0
 	},
 /obj/item/food/salami,
@@ -464,6 +466,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = -24;
+	pixel_y = 0;
 	environ = 0
 	},
 /turf/open/floor/iron/corner{
@@ -738,10 +741,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
-	dir = 2;
-	environ = 0;
 	pixel_x = 0;
-	pixel_y = -24
+	pixel_y = -24;
+	environ = 0
 	},
 /turf/open/floor/wood,
 /area/awaymission/bmpship/fore/bridge/caproom)
@@ -1048,6 +1050,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = -24;
+	pixel_y = 0;
 	environ = 0
 	},
 /turf/open/floor/iron/white/textured_half{
@@ -1167,7 +1170,7 @@
 /turf/open/floor/iron/corner,
 /area/awaymission/bmpship/aft/engineering)
 "dq" = (
-/obj/effect/mapping_helpers/smart_pipe/simple/general/visible,
+/obj/effect/mapping_helpers/smart_pipe/simple/general/hidden,
 /turf/closed/wall/mineral/titanium/overspace,
 /area/awaymission/bmpship/aft/engineering)
 "dr" = (
@@ -1230,6 +1233,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = -24;
+	pixel_y = 0;
 	environ = 0
 	},
 /obj/structure/cable,
@@ -1881,6 +1885,9 @@
 /obj/effect/turf_decal/siding/thinplating/end{
 	color = "#62676b"
 	},
+/obj/effect/mapping_helpers/smart_pipe/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/awaymission/bmpship/aft/engineering)
 "fe" = (
@@ -2409,6 +2416,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = 24;
+	pixel_y = 0;
 	environ = 0
 	},
 /turf/open/floor/iron/half{
@@ -2465,16 +2473,10 @@
 /obj/item/screwdriver,
 /obj/item/screwdriver,
 /obj/item/crowbar,
-/obj/machinery/power/apc/unlocked{
-	pixel_x = -24;
-	environ = 0
-	},
-/obj/structure/cable,
 /obj/effect/spawner/lootdrop/toolbox,
 /turf/open/floor/iron/large,
 /area/awaymission/bmpship/aft/engineering)
 "gH" = (
-/obj/structure/cable,
 /obj/effect/spawner/lootdrop/powercell,
 /obj/structure/lattice/catwalk/plated,
 /obj/effect/decal/cleanable/dirt,
@@ -2595,6 +2597,11 @@
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/clothes,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/unlocked{
+	pixel_x = -24;
+	pixel_y = 0;
+	environ = 0
+	},
 /turf/open/floor/iron/half{
 	dir = 1
 	},
@@ -2659,6 +2666,12 @@
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
 /obj/effect/spawner/lootdrop/powercell,
+/obj/machinery/power/apc/unlocked{
+	pixel_x = -24;
+	pixel_y = 0;
+	environ = 0
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/awaymission/bmpship/aft/engineering)
 "he" = (
@@ -3120,6 +3133,7 @@
 /obj/structure/low_wall/plastitanium,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = -24;
+	pixel_y = 0;
 	environ = 0
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -3867,8 +3881,8 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/bmpship/fore)
 "kn" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/awaymission/bmpship/aft/tribay)
+/turf/closed/wall/mineral/titanium/interior,
+/area/awaymission/bmpship/aft/storage)
 "ko" = (
 /obj/item/clothing/suit/caution,
 /obj/item/mop,
@@ -4343,6 +4357,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
 	pixel_x = -24;
+	pixel_y = 0;
 	environ = 0
 	},
 /obj/item/plate,
@@ -4401,12 +4416,12 @@
 	},
 /turf/open/floor/eighties/red,
 /area/awaymission/bmpship/midship/atrium)
-"Ik" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/awaymission/bmpship/aft/quarters)
-"Wd" = (
+"Hg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/half,
+/area/awaymission/bmpship/aft/storage)
+"Nu" = (
+/turf/closed/wall/mineral/titanium/overspace,
 /area/awaymission/bmpship/aft/quarters)
 
 (1,1,1) = {"
@@ -6866,7 +6881,7 @@ aa
 an
 aA
 ba
-bc
+Hg
 bz
 cb
 an
@@ -6981,8 +6996,8 @@ aa
 aa
 an
 aD
-bc
-bc
+Hg
+Hg
 bz
 cd
 an
@@ -7057,7 +7072,7 @@ jD
 jP
 kh
 kB
-Wd
+bc
 ao
 aa
 aa
@@ -7098,7 +7113,7 @@ aa
 an
 aE
 be
-bc
+Hg
 bz
 cE
 an
@@ -7168,7 +7183,7 @@ hb
 hI
 iv
 hb
-kn
+aj
 jI
 jR
 ki
@@ -7211,9 +7226,9 @@ aa
 aa
 aa
 aa
-aj
+kn
 aD
-bc
+Hg
 be
 aF
 cH
@@ -7269,13 +7284,13 @@ aa
 aa
 aa
 aa
-aj
+kn
 aG
 br
 bw
 aD
 cI
-aj
+kn
 gB
 gB
 gB
@@ -7327,12 +7342,12 @@ aa
 aa
 aa
 aa
-aj
+kn
 aI
-aj
-aj
+kn
+kn
 bZ
-aj
+kn
 an
 dX
 eW
@@ -7347,7 +7362,7 @@ jL
 jS
 kj
 kD
-Wd
+bc
 ao
 aa
 aa
@@ -7385,13 +7400,13 @@ aa
 aa
 aa
 aa
-aj
+kn
 aJ
 bs
-aj
+kn
 ca
 cJ
-aj
+kn
 cM
 hN
 iD
@@ -7444,12 +7459,12 @@ aa
 aa
 aa
 ap
-aj
+kn
 ap
 ap
 ap
-aj
-aj
+kn
+kn
 dp
 eY
 gc
@@ -7460,11 +7475,11 @@ gJ
 jf
 dk
 ao
-Ik
+Nu
 ao
 ao
-Ik
-Ik
+Nu
+Nu
 aa
 aa
 aa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

APCs apparently do not have directional subtypes, but rather rely on manual dir select to automatically apply pixel shifts. Vile.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes APC shifting on crashedship.dmm.

## Changelog
:cl:
fix: Fixed APCs on crashedship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
