### PR TITLE
integrates ffprobe and sorts jukebox songs by artist

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -127,6 +127,7 @@
 #define INIT_ORDER_TICKER 55
 #define INIT_ORDER_TCG 55
 #define INIT_ORDER_REAGENTS 55 //HAS to be before mapping - mapping creates objects, which creates reagents, which relies on lists made in this subsystem
+#define INIT_ORDER_SHUTTLECOMMS 51 // right before mapping places these things
 #define INIT_ORDER_MAPPING 50
 #define INIT_ORDER_TIMETRACK 47
 #define INIT_ORDER_NETWORKS 45
@@ -148,7 +149,6 @@
 #define INIT_ORDER_STICKY_BAN -10
 #define INIT_ORDER_LIGHTING -20
 #define INIT_ORDER_SHUTTLE -21
-#define INIT_ORDER_SHUTTLECOMMS -22
 #define INIT_ORDER_MINOR_MAPPING -40
 #define INIT_ORDER_PATH -50
 #define INIT_ORDER_DISCORD -60

--- a/code/controllers/configuration/entries/phoenix.dm
+++ b/code/controllers/configuration/entries/phoenix.dm
@@ -7,3 +7,7 @@
 	config_entry_value = 1
 	integer = FALSE
 	min_val = 0.1
+
+/datum/config_entry/string/ffprobe_path //filepath (including the file and its extension) for ffprobe for reading jukebox song metadata
+	config_entry_value = ""
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN

--- a/code/controllers/subsystem/jukebox.dm
+++ b/code/controllers/subsystem/jukebox.dm
@@ -126,6 +126,7 @@ SUBSYSTEM_DEF(jukebox)
 	track.song_path = file("[global.config.directory]/jukebox_music/sounds/[filename]")
 	var/list/param_list = splittext(filename,"+")
 	if(param_list.len == 3)
+		track.song_artist = "uncredited"
 		track.song_title = param_list[1]
 		track.song_length = ((text2num(param_list[2]) / 10) SECONDS)
 		track.song_beat = ((text2num(param_list[3]) / 60) SECONDS)

--- a/code/controllers/subsystem/jukebox.dm
+++ b/code/controllers/subsystem/jukebox.dm
@@ -88,7 +88,6 @@ SUBSYSTEM_DEF(jukebox)
 	var/list/shelleo_output = world.shelleo("[ffprobe_path] ./[global.config.directory]/jukebox_music/sounds/[songfilename] -hide_banner -of json -v quiet -show_streams")
 	if(shelleo_output[1] != 0)
 		CRASH("ffprobe exit code [shelleo_output[1]] - Either ffprobe_path is incorrect, or config/jukebox_music/sounds/[songfilename] is not a correct file.")
-		return null
 	var/list/decodedstdout = json_decode(shelleo_output[2])
 	var/duration = text2num(decodedstdout["streams"][1]["duration"])
 	var/list/tags = decodedstdout["streams"][1]["tags"]

--- a/code/controllers/subsystem/jukebox.dm
+++ b/code/controllers/subsystem/jukebox.dm
@@ -80,12 +80,14 @@ SUBSYSTEM_DEF(jukebox)
 /datum/controller/subsystem/jukebox/proc/free_channel(channel)
 	free_channels += channel
 
+/// attempts to call ffprobe to get metadata from an audio file in the jukebox sounds. songfilename should include file extension.
 /datum/controller/subsystem/jukebox/proc/ffprobe(songfilename as text)
 	var/ffprobe_path = CONFIG_GET(string/ffprobe_path)
 	if(ffprobe_path == "")
 		CRASH("Called ffprobe with no path set! Check config/phoenix.txt")
 	var/list/shelleo_output = world.shelleo("[ffprobe_path] ./[global.config.directory]/jukebox_music/sounds/[songfilename] -hide_banner -of json -v quiet -show_streams")
 	if(shelleo_output[1] != 0)
+		CRASH("ffprobe exit code [shelleo_output[1]] - Either ffprobe_path is incorrect, or config/jukebox_music/sounds/[songfilename] is not a correct file.")
 		return null
 	var/list/decodedstdout = json_decode(shelleo_output[2])
 	var/duration = text2num(decodedstdout["streams"][1]["duration"])
@@ -94,7 +96,7 @@ SUBSYSTEM_DEF(jukebox)
 	var/title = tags["title"]
 	if(isnull(artist) || isnull(title) || isnull(duration))
 		return null
-	return list("artist" = artist, "title" = title, "duration" = duration)
+	return list(artist, title, duration)
 
 /datum/controller/subsystem/jukebox/proc/is_ffprobe_path_set()
 	return CONFIG_GET(string/ffprobe_path) != ""

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -94,7 +94,8 @@
 	data["songs"] = list()
 	for(var/datum/jukebox_track/S in songs)
 		var/list/track_data = list(
-			name = "[S.song_artist] - [S.song_title]"
+			name = S.song_title,
+			artist = S.song_artist,
 		)
 		data["songs"] += list(track_data)
 	data["track_selected"] = null

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -10,7 +10,7 @@
 	/// Reference to the song list from the jukebox subsystem.
 	var/static/list/songs
 	/// Currently selected artist
-	var/artist_selected
+	var/artist_selected = "uncredited"
 	/// Currently selected track.
 	var/datum/jukebox_track/selection
 	/// Currently played track.

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -140,13 +140,16 @@
 			if(active)
 				to_chat(usr, SPAN_WARNING("Error: You cannot change the song until the current one is over."))
 				return
-			var/list/available = list()
-			for(var/datum/jukebox_track/S in songs)
-				available["[S.song_artist] - [S.song_title]"] = S
-			var/selected = params["track"]
-			if(QDELETED(src) || !selected || !istype(available[selected], /datum/jukebox_track))
+			var/selected_title = params["track_title"]
+			var/selected_artist = params["track_artist"]
+
+			if(QDELETED(src) || !selected_title || !selected_artist)
 				return
-			selection = available[selected]
+
+			for(var/datum/jukebox_track/S in songs)
+				if(S.song_title == selected_title && S.song_artist == selected_artist)
+					selection = S
+					break
 			return TRUE
 		if("set_volume")
 			var/new_volume = params["volume"]

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -9,6 +9,8 @@
 	var/active = FALSE
 	/// Reference to the song list from the jukebox subsystem.
 	var/static/list/songs
+	/// Currently selected artist
+	var/artist_selected
 	/// Currently selected track.
 	var/datum/jukebox_track/selection
 	/// Currently played track.
@@ -87,6 +89,8 @@
 /obj/machinery/jukebox/ui_data(mob/user)
 	var/list/data = list()
 	data["active"] = active
+	data["artists"] = SSjukebox.artists
+	data["artist_selected"] = artist_selected
 	data["songs"] = list()
 	for(var/datum/jukebox_track/S in songs)
 		var/list/track_data = list(
@@ -127,6 +131,10 @@
 				/// Deleting the track stops the song.
 				qdel(played_track)
 				return TRUE
+		if("select_artist")
+			var/selected = params["artist"]
+			if(SSjukebox.artists.Find(selected))
+				artist_selected = selected
 		if("select_track")
 			if(active)
 				to_chat(usr, SPAN_WARNING("Error: You cannot change the song until the current one is over."))

--- a/code/modules/shuttle_comms/SSshuttlecomms.dm
+++ b/code/modules/shuttle_comms/SSshuttlecomms.dm
@@ -6,18 +6,29 @@ SUBSYSTEM_DEF(shuttlecomms)
 	runlevels = RUNLEVEL_GAME
 	init_order = INIT_ORDER_SHUTTLECOMMS
 	var/list/obj/machinery/shuttle_comms/comms
+	var/list/obj/machinery/shuttle_comms/active/ruin_comms
 
 /datum/controller/subsystem/shuttlecomms/Initialize(start_timeofday)
 	comms = list()
+	ruin_comms = list()
 	return ..()
 
 /datum/controller/subsystem/shuttlecomms/fire(resumed)
 	for(var/obj/machinery/shuttle_comms/array in comms)
 		array.monitor()
-	return
+	for(var/obj/machinery/shuttle_comms/active/ruin_array in ruin_comms)
+		ruin_array.monitor()
 
 /datum/controller/subsystem/shuttlecomms/proc/add_array(obj/machinery/shuttle_comms/array)
-	comms += array
+	if(istype(array, /obj/machinery/shuttle_comms/active))
+		ruin_comms.Add(array)
+		return
+	if(istype(array))
+		comms.Add(array)
 
 /datum/controller/subsystem/shuttlecomms/proc/remove_array(obj/machinery/shuttle_comms/array)
-	comms -= array
+	if(istype(array, /obj/machinery/shuttle_comms/active))
+		comms.Remove(array)
+		return
+	if(istype(array))
+		comms.Remove(array)

--- a/config/phoenix.txt
+++ b/config/phoenix.txt
@@ -4,3 +4,7 @@ AUTOSHELL_POP 8
 
 ## multiplier for simple_animal/hostile maxhealth.
 HOSTILE_HEALTH_MULT 1.5
+
+## file system path for ffprobe if it exists.
+#  just comment this out if you dont have it.
+# FFPROBE_PATH C:\ffprobe.exe

--- a/config/phoenix.txt
+++ b/config/phoenix.txt
@@ -6,5 +6,6 @@ AUTOSHELL_POP 8
 HOSTILE_HEALTH_MULT 1.5
 
 ## file system path for ffprobe if it exists.
-#  just comment this out if you dont have it.
+#  this makes the jukebox system a lot more convenient to use,
+#  but just comment this out if you dont have it or don't want to use it.
 # FFPROBE_PATH C:\ffprobe.exe

--- a/tgui/packages/tgui/interfaces/Jukebox.js
+++ b/tgui/packages/tgui/interfaces/Jukebox.js
@@ -49,7 +49,7 @@ export const Jukebox = (props, context) => {
               <Dropdown
                 overflow-y="scroll"
                 width="240px"
-                options={songs.filter(song => song.artist === artist_selected)
+                options={songs.filter(song => (song.artist === artist_selected))
                   .map(song => song.name)}
                 disabled={active}
                 selected={track_selected || "Select a Track"}

--- a/tgui/packages/tgui/interfaces/Jukebox.js
+++ b/tgui/packages/tgui/interfaces/Jukebox.js
@@ -54,7 +54,8 @@ export const Jukebox = (props, context) => {
                 disabled={active}
                 selected={track_selected || "Select a Track"}
                 onSelected={value => act('select_track', {
-                  track: value,
+                  track_title: value,
+                  track_artist: artist_selected,
                 })} />
             </LabeledList.Item>
             <LabeledList.Item label="Track Length">

--- a/tgui/packages/tgui/interfaces/Jukebox.js
+++ b/tgui/packages/tgui/interfaces/Jukebox.js
@@ -1,6 +1,6 @@
 import { sortBy } from 'common/collections';
 import { flow } from 'common/fp';
-import { useBackend } from '../backend';
+import { useLocalState, useBackend } from '../backend';
 import { Box, Button, Dropdown, Section, Knob, LabeledControls, LabeledList } from '../components';
 import { Window } from '../layouts';
 
@@ -8,6 +8,8 @@ export const Jukebox = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     active,
+    artists,
+    artist_selected,
     track_selected,
     track_length,
     track_beat,
@@ -32,11 +34,23 @@ export const Jukebox = (props, context) => {
               onClick={() => act('toggle')} />
           )}>
           <LabeledList>
+            <LabeledList.Item label="Artist">
+              <Dropdown
+                overflow-y="scroll"
+                width="240px"
+                options={artists}
+                disabled={active}
+                selected={selectedArtist || "Select an artist"}
+                onSelected={value => act('select_artist', {
+                  artist: value,
+                })} />
+            </LabeledList.Item>
             <LabeledList.Item label="Track Selected">
               <Dropdown
                 overflow-y="scroll"
                 width="240px"
-                options={songs.map(song => song.name)}
+                options={songs.filter(song => song.artist === selectedArtist)
+                  .map(song => song.name)}
                 disabled={active}
                 selected={track_selected || "Select a Track"}
                 onSelected={value => act('select_track', {

--- a/tgui/packages/tgui/interfaces/Jukebox.js
+++ b/tgui/packages/tgui/interfaces/Jukebox.js
@@ -40,7 +40,7 @@ export const Jukebox = (props, context) => {
                 width="240px"
                 options={artists}
                 disabled={active}
-                selected={selectedArtist || "Select an artist"}
+                selected={artist_selected || "Select an artist"}
                 onSelected={value => act('select_artist', {
                   artist: value,
                 })} />
@@ -49,7 +49,7 @@ export const Jukebox = (props, context) => {
               <Dropdown
                 overflow-y="scroll"
                 width="240px"
-                options={songs.filter(song => song.artist === selectedArtist)
+                options={songs.filter(song => song.artist === artist_selected)
                   .map(song => song.name)}
                 disabled={active}
                 selected={track_selected || "Select a Track"}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: added FFPROBE_PATH config
qol: jukebox songs now sort and filter by artist for easier menu navigation
server: jukebox audio files can now have metadata parsed by ffprobe if ffmpeg is installed. it won't bother if FFPROBE_PATH isn't set, so if you don't want it just don't use it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
